### PR TITLE
Limit vagrant fields to 4

### DIFF
--- a/ch03/inventory/vagrant.py
+++ b/ch03/inventory/vagrant.py
@@ -21,7 +21,7 @@ def list_running_hosts():
     status = subprocess.check_output(cmd.split()).rstrip()
     hosts = []
     for line in status.split('\n'):
-        (_, host, key, value) = line.split(',')
+        (_, host, key, value) = line.split(',')[:4]
         if key == 'state' and value == 'running':
             hosts.append(host)
     return hosts


### PR DESCRIPTION
Vagrant metadata contains 5 fields which breaks the script:
1455035554,vagrant1,metadata,provider,virtualbox

vagrant --version
Vagrant 1.8.1
